### PR TITLE
Expose `term::show_console()` for QoL help with signal handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,28 @@ s.stop_with("🥬", "spinach'd", Color::Ignore);
 s.stop_with(None, None, Color::Blue);
 ```
 
+## FAQ
+
+### How to avoid leaving terminal without prompt on interupt (ctrl^c)?
+
+You can use a library like [`ctrlc`](https://crates.io/crates/ctrlc) to handle interupts.
+
+The most basic way to handle it would be in conjuction with this lib QoL `show_cursor` function like this:
+
+```rust
+use spinach::{term, Spinach};
+
+fn main() {
+    ctrlc::set_handler(|| {
+        term::show_cursor();
+        std::process::exit(0);
+    })
+    .expect("Error setting Ctrl-C handler");
+
+    let s = Spinach::new("spinnin'");
+    // ...
+```
+
 ## Related
 
 Inspired by:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,8 @@ pub use crate::term::Color;
 
 mod context;
 mod spinner;
-mod term;
+
+pub mod term;
 
 /// Spinach spinner.
 ///
@@ -327,6 +328,7 @@ impl Spinach {
         Self { sender, handle }
     }
 }
+
 enum SpinnerCommand {
     Update {
         text: Option<&'static str>,

--- a/src/term.rs
+++ b/src/term.rs
@@ -33,7 +33,20 @@ pub(crate) fn hide_cursor() {
     print!("\x1b[?25l")
 }
 
-pub(crate) fn show_cursor() {
+/// Print show cursor ANSI escape code
+///
+/// Can be used when managing ctrl^c/SIGINT to show the cursor back
+///
+/// # Examples
+///
+/// ```
+/// use spinach;
+///
+/// let s = spinach::Spinach::new("Cutting spinaches");
+/// // somehow `s` is droped
+/// spinach::term::show_cursor();
+/// ```
+pub fn show_cursor() {
     print!("\x1b[?25h")
 }
 


### PR DESCRIPTION
Sending ctrl^c/SIGINT/SIGTERM, the user will end up without cursor if there was an active spinner.

`term::show_cursor()` can help people fix that in conjunction with signal handling