### PR TITLE
Manage strings as input

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -3,15 +3,15 @@ use crate::term;
 
 pub(crate) struct Context {
     pub spinner: Spinner,
-    pub text: &'static str,
+    pub text: String,
     pub color: term::Color,
 }
 
 impl Default for Context {
     fn default() -> Self {
         let spinner = Spinner::default();
-        let text = "";
-        let color = term::Color::Ignore;
+        let text = String::default();
+        let color = term::Color::default();
         Self {
             spinner,
             text,
@@ -24,7 +24,7 @@ impl Context {
     pub fn render(&mut self) {
         Self::print(
             self.spinner.next().unwrap_or_default(),
-            self.text,
+            &self.text,
             &self.color,
         );
     }
@@ -32,14 +32,14 @@ impl Context {
     pub fn render_with_override(
         &mut self,
         spinner_frame: Option<&str>,
-        text: Option<&str>,
+        text: Option<String>,
         color: Option<term::Color>,
     ) {
         let spinner_frame =
             spinner_frame.unwrap_or_else(|| self.spinner.next().unwrap_or_default());
-        let text = text.unwrap_or(self.text);
+        let text = text.unwrap_or_else(|| self.text.clone());
         let color = color.unwrap_or_else(|| self.color.clone());
-        Self::print(spinner_frame, text, &color);
+        Self::print(spinner_frame, &text, &color);
     }
 
     pub fn print(spinner_frame: &str, text: &str, color: &term::Color) {

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -1,0 +1,36 @@
+pub struct OptText {
+    pub inner: Option<String>,
+}
+
+impl Default for OptText {
+    fn default() -> Self {
+        Self { inner: None }
+    }
+}
+
+impl From<String> for OptText {
+    fn from(string: String) -> Self {
+        Self {
+            inner: Some(string),
+        }
+    }
+}
+
+impl From<&str> for OptText {
+    fn from(string_slice: &str) -> Self {
+        Self {
+            inner: Some(string_slice.to_string()),
+        }
+    }
+}
+
+impl From<Option<&str>> for OptText {
+    fn from(option: Option<&str>) -> Self {
+        match option {
+            Some(string_slice) => Self {
+                inner: Some(string_slice.to_string()),
+            },
+            None => Self::default(),
+        }
+    }
+}

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -1,11 +1,6 @@
+#[derive(Default)]
 pub struct OptText {
     pub inner: Option<String>,
-}
-
-impl Default for OptText {
-    fn default() -> Self {
-        Self { inner: None }
-    }
 }
 
 impl From<String> for OptText {


### PR DESCRIPTION
Doesn't rely on static literal strings.
The previous design didn't let us use dynamic texts in spinners.