### PR TITLE
cloneable spinners and nameable states

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,5 +2,5 @@ mod spinner;
 mod state;
 mod term;
 
-pub use spinner::Spinner;
+pub use spinner::{RunningSpinner, Spinner, StoppedSpinner};
 pub use term::{show_cursor, Color};

--- a/src/spinner.rs
+++ b/src/spinner.rs
@@ -36,6 +36,12 @@ pub struct Running {
     handle: RefCell<Option<JoinHandle<()>>>,
 }
 
+/// Represents a spinner that is currently running.
+pub type RunningSpinner = Spinner<Running>;
+
+/// Represents a spinner that is currently stopped.
+pub type StoppedSpinner = Spinner<Stopped>;
+
 impl<S> Spinner<S> {
     /// Sets the color of the spinner.
     ///

--- a/src/spinner.rs
+++ b/src/spinner.rs
@@ -1,4 +1,5 @@
 use std::cell::RefCell;
+use std::rc::Rc;
 use std::sync::mpsc::{channel, Sender, TryRecvError};
 use std::thread::{sleep, spawn, JoinHandle};
 use std::time::Duration;
@@ -26,14 +27,14 @@ pub struct Spinner<S> {
 }
 
 /// Represents the stopped state of a spinner.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Stopped;
 
 /// Represents the running state of a spinner.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Running {
     sender: Sender<Update>,
-    handle: RefCell<Option<JoinHandle<()>>>,
+    handle: Rc<RefCell<Option<JoinHandle<()>>>>,
 }
 
 /// Represents a spinner that is currently running.
@@ -173,7 +174,7 @@ impl Spinner<Stopped> {
             term::new_line();
             term::show_cursor();
         })));
-
+        let handle = Rc::new(handle);
         Spinner {
             update: RefCell::new(Update::default()),
             state: Running { sender, handle },


### PR DESCRIPTION
Thanks for writing `spinach`, it's great! I found a couple of papercuts when using `spinach` in a small command line utility related to error handling:

Starting a `Spinner` and doing some computation with early returns (especially with `?`) and wanting to update the spinner to reflect a failure is a bit tricky - you need to stop the spinner in all the early return branches and avoid using `?` and stop the spinner in the manual `match` instead, e.g.

```rust
let status = Spinner::new("Doing something...").start();
// `status` not updated on early return:
let _ = first_computation()?;
second_computation()?;
status.text("Finished something").success();

// ..becomes ..

let status = Spinner::new("Doing something...").start();
let _ = match first_computation() {
    Ok(v) => v,
    Err(e) => {
        status.text("Doing something failed").failure();
        return Err(e);
    }
};
if let Err(e) = second_computation() {
    status.text("Doing something failed").failure();
    return Err(e);
}
status.text("Finished something").success();
```

Instead, I wanted to clone the spinner into my `Error` type, add a `map_err` call and handle the failure message for the spinner in the same place as my other error handling.

```rust
fn primary_task() -> Result<(), Error> {
    let status = Spinner::new("Doing something...").start();
    let _ = first_computation()
        .map_err(|e| Error::Computation(status.clone(), e))?;
    second_computation()
        .map_err(|e| Error::Computation(status.clone(), e))?;
    status.text("Finished something").success();
    Ok(())
}

fn main() {
    if let Err(e) = primary_task() { e.stop_spinners(); }
}
```

It isn't possible to do this with `spinach` currently - `Stopped`/`Running` aren't public so `Spinner<Running>` can't be named and added to my error type. I could use a generic here (`struct Error<S>(Spinner<S>)`) isn't particularly nice because everywhere that I used the error type would also need to be generic - it also just doesn't work, `Spinner::stop` is only defined on a `Spinner<Running>` and I still can't name that.

In 21fdd8b6c86bc3c36eb252d0958ec751ff6de792, I add type aliases for `Spinner<Running>` so that I can name this without making the states themselves nameable, but then you need to be able to clone `Spinner`, it implements `Clone` if the states do, but neither do. `Stopped` can be `Clone` trivially, but `Running` can't because of `JoinHandle`.

In 73314bb22e0971da6c442cceb7328b7e82ed9f36, I add a variant of `Running` that wraps the `JoinHandle` field in a `Rc` so that it can be cloned - I could make this the default for `Running` if you wanted.

Happy to make whatever changes you want for this to have the interface you'd like it to have.